### PR TITLE
Add publications

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,20 @@
+# Originally from nyradr/limecv
+
+RM=rm -rf *.aux *.log *.out mwe*.pdf *.glo *.idx *.cls
+
+all: src/limecv.cls
+
+src/limecv.cls: src/limecv.dtx src/limecv.ins
+	cd src; $(RM); pdflatex limecv.ins
+
+examples: examples/limecv-icon.pdf examples/mwe-latex.tex examples/mwe-lualatex.tex examples/mwe-xelatex.tex examples/picture.png src/limecv.cls
+	cp src/limecv.cls examples/limecv.cls
+	cd examples; pdflatex mwe-latex.tex;    pdflatex mwe-latex.tex
+	cd examples; xelatex mwe-xelatex.tex;   xelatex mwe-xelatex.tex
+	cd examples; lualatex mwe-lualatex.tex; lualatex mwe-lualatex.tex
+
+clean:
+	$(RM)
+	cd src; $(RM)
+	cd examples; $(RM)
+

--- a/src/limecv.dtx
+++ b/src/limecv.dtx
@@ -1583,6 +1583,7 @@ Dear Miss.\ Smith
     \pgfkeys{/@cv/names/experience = Experience}%
     \pgfkeys{/@cv/names/references = References}%
     \pgfkeys{/@cv/names/skills = Skills}%
+    \pgfkeys{/@cv/names/publications = Publications}%
 }
 %    \end{macrocode}
 %
@@ -1600,6 +1601,7 @@ Dear Miss.\ Smith
     \pgfkeys{/@cv/names/experience = Werkervaring}%
     \pgfkeys{/@cv/names/references = Referenties}%
     \pgfkeys{/@cv/names/skills = Vaardigheden}%
+    \pgfkeys{/@cv/names/publications = Publicaties}%
 }
 %    \end{macrocode}
 %
@@ -1755,6 +1757,26 @@ Dear Miss.\ Smith
   \stepcounter{cv@lastItem}
   \draw (skills.south west) node %
     (cv@last item \the\value{cv@lastItem}) {};
+}
+%    \end{macrocode}
+%------------------------------------------------------
+%
+%   cvPublications environment
+%
+%    \begin{macrocode}
+\NewDocumentEnvironment{cvPublications}{}{%
+\cv@Title{\pgfkeysvalueof{/@cv/names/publications}}{\faNewspaperO}
+%    \end{macrocode}
+% insures uniqueness
+%    \begin{macrocode}
+  \stepcounter{cv@itemPrev}
+  \stepcounter{cv@itemNext}
+  \cv@definecvItem
+}{%
+  \cv@EndSectionDraw
+  \stepcounter{cv@lastItem}
+  \draw (item \the\value{cv@itemPrev}.south west)
+    node (cv@last item \the\value{cv@lastItem}) {};
 }
 %    \end{macrocode}
 %------------------------------------------------------


### PR DESCRIPTION
Relates to #5.

Here's my small addition to the limecv style to add a Publications section - it uses the FA Newspaper Icon because I couldn't find a better one.

My resume requires the additional items in the header to work:

```tex
\usepackage[backend=biber]{biblatex}                                  
\addbibresource{mylib.bib}
```

and then full references are placed in cv items as such:

```tex
    \begin{cvPublications}
        \cvItem{ \fullcite{cite1} };
        \cvItem{ \fullcite{cite2} };
        \cvItem{ \fullcite{cite3} };
    \end{cvPublications}
```

I haven't added documentation yet, and I'd appreciate your help there